### PR TITLE
Changed WINDOWS_NT to Windows_NT

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ CC = gcc
 LIBS := 
 LDFLAGS := 
 
-ifeq ($(OS), WINDOWS_NT)
+ifeq ($(OS), Windows_NT)
 	LIBS += -llibraylib -lopengl32 -lgdi32 -lwinmm
 	LDFLAGS = -L.
 else
@@ -13,6 +13,6 @@ else
 endif
 
 flappybinchicken: main.c raylib.h
-	$(CC) -o flappybinchicken main.c $(LIBS)
-
+	$(CC) -o flappybinchicken main.c $(LDFLAGS) $(LIBS)
+	$(info FlappyBinChicken successfully compiled!)
 


### PR DESCRIPTION
- `ifeq($(OS), WINDOWS_NT)` was changed to `ifeq($OS, Windows_NT)`.
- `$(LDFLAGS)` was added to the build command.
- Little info message to indicate that the project had been compiled was also added.