### PR TITLE
raylib submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "raylib"]
+	path = raylib
+	url = https://github.com/raysan5/raylib.git


### PR DESCRIPTION
Incorporated @FOMX solution to include raylib as a submodule to ensure that people could clone and build the project even if they don't have raylib already installed and configured on their machine.

There is a master makefile that is responsible for running the makefile in `raylib/` and `game/`. The makefile in `raylib/` is the one built by the developers of raylib, and the one in `game/` just checks which operating system you're on and sets the appropriate library paths and gcc flags.

@FOMX thx bruv
